### PR TITLE
Fix build with GCC 14

### DIFF
--- a/vncauth.c
+++ b/vncauth.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "vncauth.h"

--- a/vncauth.h
+++ b/vncauth.h
@@ -25,6 +25,8 @@
 #define CHALLENGESIZE 16
 
 extern int vncEncryptAndStorePasswd(char *passwd, char *fname);
+extern int vncEncryptAndStorePasswd2(char *passwd, char *passwdViewOnly, char *fname);
 extern char *vncDecryptPasswdFromFile(char *fname);
+extern int vncDecryptPasswdFromFile2(char *fname, char *passwdFullControl, char *passwdViewOnly);
 extern void vncRandomBytes(unsigned char *bytes);
 extern void vncEncryptBytes(unsigned char *bytes, char *passwd);


### PR DESCRIPTION
GCC 14 fails on missing function definitions. Include the header for time(), and define some functions in our header.